### PR TITLE
Active Record 7 Update

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,7 +13,7 @@
 Bundler/OrderedGems:
   Exclude:
     - 'Gemfile'
-    - 'gemfiles/ar60.gemfile'
+    - 'gemfiles/ar70.gemfile'
 
 # Offense count: 2
 # Cop supports --auto-correct.

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,10 @@ dist: xenial
 language: ruby
 sudo: false
 rvm:
-  - 2.6
-  - 2.5
+  - 2.7
   - jruby-9.2.6.0
 gemfile:
-  - gemfiles/ar60.gemfile
+  - gemfiles/ar70.gemfile
 matrix:
   allow_failures:
     - rvm: jruby-9.2.6.0

--- a/Appraisals
+++ b/Appraisals
@@ -1,3 +1,3 @@
-appraise "ar60" do
-  gem "activerecord", "~> 6.0.0"
+appraise "ar70" do
+  gem "activerecord", "~> 7.0.0"
 end

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,8 +41,8 @@ Run tests against the test gemfiles:
 run `rake appraisal` or run the tests manually:
 
 ```
-BUNDLE_GEMFILE=./gemfiles/ar60.gemfile bundle
-BUNDLE_GEMFILE=./gemfiles/ar60.gemfile rake
+BUNDLE_GEMFILE=./gemfiles/ar70.gemfile bundle
+BUNDLE_GEMFILE=./gemfiles/ar70.gemfile rake
 ```
 
 Make your changes and submit a pull request.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ gem 'ffi-geos'
 
 _JRuby support for Rails 4.0 and 4.1 was added in version 2.2.0_
 
+#### Version 7.x supports ActiveRecord 7.0+
+
+Requirements:
+
+```
+ActiveRecord 7.0+
+Ruby 2.7+ (no JRuby support yet)
+PostGIS 2.0+
+```
+
 #### Version 6.x supports ActiveRecord 6.0+
 
 Requirements:

--- a/activerecord-mysql2rgeo-adapter.gemspec
+++ b/activerecord-mysql2rgeo-adapter.gemspec
@@ -19,9 +19,9 @@ Gem::Specification.new do |spec|
   spec.files = Dir["lib/**/*", "LICENSE.txt"]
   spec.platform = Gem::Platform::RUBY
 
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
-  spec.add_dependency "activerecord", "~> 6.1"
+  spec.add_dependency "activerecord", "~> 7.0.0"
   spec.add_dependency "rgeo-activerecord", "~> 7.0.0"
 
   spec.add_development_dependency "rake", "~> 13.0"

--- a/gemfiles/ar70.gemfile
+++ b/gemfiles/ar70.gemfile
@@ -6,6 +6,6 @@ gem "mysql2", "~> 0.5.2", platform: :ruby
 gem "jdbc-mysql", platform: :jruby
 gem "activerecord-jdbc-adapter", "~> 5.0", platform: :jruby
 gem "ffi-geos", platform: :jruby
-gem "activerecord", "~> 6.1.0"
+gem "activerecord", "~> 7.0.0"
 
 gemspec path: "../"

--- a/lib/active_record/connection_adapters/mysql2rgeo/schema_statements.rb
+++ b/lib/active_record/connection_adapters/mysql2rgeo/schema_statements.rb
@@ -26,42 +26,6 @@ module ActiveRecord
           super
         end
 
-        # override
-        def native_database_types
-          # Add spatial types
-          # Reference: https://dev.mysql.com/doc/refman/5.6/en/spatial-type-overview.html
-          super.merge(
-            geometry:            { name: "geometry" },
-            geometrycollection:  { name: "geometrycollection" },
-            linestring:          { name: "linestring" },
-            multi_line_string:   { name: "multilinestring" },
-            multi_point:         { name: "multipoint" },
-            multi_polygon:       { name: "multipolygon" },
-            spatial:             { name: "geometry" },
-            point:               { name: "point" },
-            polygon:             { name: "polygon" }
-          )
-        end
-
-        def initialize_type_map(m = type_map)
-          super
-
-          %w[
-            geometry
-            geometrycollection
-            point
-            linestring
-            polygon
-            multipoint
-            multilinestring
-            multipolygon
-          ].each do |geo_type|
-            m.register_type(geo_type) do |sql_type|
-              Type::Spatial.new(sql_type)
-            end
-          end
-        end
-
         private
 
         # override

--- a/lib/active_record/connection_adapters/mysql2rgeo/version.rb
+++ b/lib/active_record/connection_adapters/mysql2rgeo/version.rb
@@ -3,7 +3,7 @@
 module ActiveRecord
   module ConnectionAdapters
     module Mysql2Rgeo
-      VERSION = "6.0.3"
+      VERSION = "7.0.0"
     end
   end
 end

--- a/lib/active_record/type/spatial.rb
+++ b/lib/active_record/type/spatial.rb
@@ -40,7 +40,9 @@ module ActiveRecord
       end
 
       def spatial_factory
-        @spatial_factory ||=
+        @spatial_factories ||= {}
+
+        @spatial_factories[@srid] ||=
           RGeo::ActiveRecord::SpatialFactoryStore.instance.factory(
             geo_type: @geo_type,
             sql_type: @sql_type,

--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -124,7 +124,7 @@ class BasicTest < ActiveSupport::TestCase
     point = object.latlon
     # assert_equal 47, point.latitude
     object.shape = point
-    assert_equal true, RGeo::Geos.is_geos?(object.shape)
+    assert_equal true, RGeo::Geos.geos?(object.shape)
 
     spatial_factory_store.clear
   end


### PR DESCRIPTION
## Why? / What?
We are blocked from upgrading to Rails 7 by this gem. In order to make this gem compatible, the ActiveRecord version had to be updated to 7. A few changes had to made to fix ~20 tests.

I will submit a PR from this forked version back to the original repo. We can use this version while we wait for their approval.

### Screenshot(s)
NA
### JIRA Link
https://sentera.atlassian.net/browse/PAGC-651
## Migrations Required?
NA
## Data Recovery Strategy
NA
## QA Strategy
- [ ] Merge Latest Master
- [ ] Full regression test
  - [ ] Web
  - [ ] API
  - [ ] Desktop
  - [ ] Mobile 
