### PR TITLE
Fix broken test checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         ruby: ['3.0', '2.7', '2.6', '2.5']
         gemfile:
-          - gemfiles/ar61.gemfile
+          - gemfiles/ar70.gemfile
         mysql: ['5.7', '8.0']
     steps:
       - name: Set Up Actions


### PR DESCRIPTION
The https://github.com/stadia/activerecord-mysql2rgeo-adapter/pull/24 I opened in the https://github.com/stadia/activerecord-mysql2rgeo-adapter repo has several GitHub checks that are failing:

![Screen Shot 2022-05-27 at 7 57 10 AM](https://user-images.githubusercontent.com/123218/170713628-7920c57c-717b-49e8-a27a-f6e5b8cc02a4.png)

![Screen Shot 2022-05-27 at 7 57 27 AM](https://user-images.githubusercontent.com/123218/170713646-ecbeff32-df7c-4876-8537-e1a83fe1683b.png)

This pull request is my attempt to fix this issue