### PR TITLE
Fix bug in ActiveRecord::ConnectionAdapters::Mysql2Rgeo::SchemaCreation#add_column_options!

### DIFF
--- a/lib/active_record/connection_adapters/mysql2rgeo/schema_creation.rb
+++ b/lib/active_record/connection_adapters/mysql2rgeo/schema_creation.rb
@@ -7,34 +7,11 @@ module ActiveRecord
         private
 
           def add_column_options!(sql, options)
-            # By default, TIMESTAMP columns are NOT NULL, cannot contain NULL values,
-            # and assigning NULL assigns the current timestamp. To permit a TIMESTAMP
-            # column to contain NULL, explicitly declare it with the NULL attribute.
-            # See https://dev.mysql.com/doc/refman/en/timestamp-initialization.html
-            if /\Atimestamp\b/.match?(options[:column].sql_type) && !options[:primary_key]
-              sql << " NULL" unless options[:null] == false || options_include_default?(options)
-            end
-
             if options[:srid]
               sql << " /*!80003 SRID #{options[:srid]} */"
             end
 
-            if charset = options[:charset]
-              sql << " CHARACTER SET #{charset}"
-            end
-
-            if collation = options[:collation]
-              sql << " COLLATE #{collation}"
-            end
-
-            if as = options[:as]
-              sql << " AS (#{as})"
-              if options[:stored]
-                sql << (mariadb? ? " PERSISTENT" : " STORED")
-              end
-            end
-
-            add_sql_comment!(super, options[:comment])
+            super
           end
       end
     end


### PR DESCRIPTION
## Why? / What?
Version 6.0.3 of this gem introduced a problem for a `db/schema.rb` that uses the `as:` option to provide additional information to the MySQL schema creation adapter to construct the database schema properly. CloudVault uses this option for the `organizations.ndvi_change_virtual` column:

```
t.virtual "ndvi_change_virtual", type: :boolean, as: "json_unquote(json_extract(`generated_notifications`,'$.ndvi_change'))"
```

The resulting SQL statement produced for this column contained a duplicate `AS json_unquote(json_extract(`generated_notifications`,'$.ndvi_change'))`, which failed when Rails tries to create a database schema from `db/schema.rb`.

This pull request changes the overridden `ActiveRecord::ConnectionAdapters::Mysql2Rgeo::SchemaCreation#add_column_options!` method to only add logic for the `options[:srid]` option, and to remove duplicate logic that is already present in ActiveRecord.

We have been using version 6.0 of this gem, so we haven't seen this issue until now when we're trying to upgrade our gems, including to Rails 7.

I will submit a PR from this forked version back to the original repo. We can use this version while we wait for their approval.

### Screenshot(s)
NA
### JIRA Link
https://sentera.atlassian.net/browse/PAGC-794
## Migrations Required?
NA
## Data Recovery Strategy
NA
## QA Strategy
- [ ] Merge Latest Master
- [ ] Regression test that recreating the local development database works correctly.
