### PR TITLE
[PLAT-2451] Fix schema dump for spatial columns in Rails 8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       BUNDLE_GEMFILE: ${{matrix.gemfile}}
     strategy:
       matrix:
-        ruby: ['3.3', '3.2', '3.1']
+        ruby: ['3.4', '3.3', '3.2']
         gemfile:
           - gemfiles/ar81.gemfile
         mysql: ['8.0']

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         ruby: ['3.3', '3.2', '3.1']
         gemfile:
-          - gemfiles/ar72.gemfile
+          - gemfiles/ar81.gemfile
         mysql: ['8.0']
     steps:
       - name: Set Up Actions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,60 @@
+# AGENTS.md — activerecord-mysql2rgeo-adapter
+
+ActiveRecord connection adapter for MySQL with built-in support for spatial (RGeo) column types.
+
+## Repository Overview
+
+- **Language:** Ruby (gem)
+- **Purpose:** Extends `Mysql2Adapter` (Rails) with spatial column types backed by the RGeo library
+- **Active branch:** `rails-8-1-support` (targets ActiveRecord 8.1 + MySQL 8.0)
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `lib/active_record/connection_adapters/mysql2rgeo_adapter.rb` | Main adapter class (`Mysql2RgeoAdapter`), type map, spatial column options |
+| `lib/active_record/connection_adapters/mysql2rgeo/spatial_column.rb` | `SpatialColumn` — extends `MySQL::Column` with spatial metadata |
+| `lib/active_record/connection_adapters/mysql2rgeo/schema_statements.rb` | `new_column_from_field` override to build spatial columns from DB metadata |
+| `lib/active_record/connection_adapters/mysql2rgeo/spatial_column_info.rb` | Queries `INFORMATION_SCHEMA` for spatial column metadata (type, srid) |
+| `lib/active_record/type/spatial.rb` | `Type::Spatial` — cast type for all spatial columns; `#type` always returns `:geometry` |
+| `test/tasks_test.rb` | Schema dump / schema load tests (most relevant to schema.rb regeneration) |
+| `test/ddl_test.rb` | Column creation / DDL tests |
+
+## Spatial Type Mapping
+
+All spatial SQL types (`geometry`, `point`, `multipolygon`, `linestring`, etc.) are registered in `Mysql2RgeoAdapter::TYPE_MAP` via `initialize_type_map`. Each maps to `Type::Spatial`, whose `#type` method always returns `:geometry`. This means:
+
+- `column.type` is `:geometry` for **all** spatial columns (geometry, point, multipolygon, etc.)
+- `column.sql_type` is the raw MySQL type (e.g. `"multipolygon"`)
+- `column.limit` returns `{ type: "multi_polygon", srid: 0 }` (snake_case form of the geometry type name)
+
+Schema dumps always write `t.geometry "col_name", limit: {...}` regardless of the underlying spatial type.
+
+## Rails 8.1 Gotcha — `valid_type?`
+
+Rails 8.1's `SchemaDumper` calls `@connection.valid_type?(column.type)` before dumping each column. The instance `valid_type?` delegates to the **class-level** `Mysql2RgeoAdapter.native_database_types`, which is inherited from `AbstractMysqlAdapter` and does NOT include spatial types. The **instance** `native_database_types` override (which does include spatial types) is not consulted by the class-level `valid_type?`.
+
+**Fix:** Override `valid_type?` at the instance level in `Mysql2RgeoAdapter` so it uses the instance `native_database_types`.
+
+## Running Tests
+
+Tests require a running MySQL 8 instance. See `test/database.yml` (or create `test/database_local.yml`) for connection config.
+
+```bash
+# Run all tests (default gemfile)
+bundle exec rake test
+
+# Run with Rails 8.1 gemfile
+BUNDLE_GEMFILE=gemfiles/ar81.gemfile bundle exec rake test
+```
+
+Use `appraisal` to test across Rails versions:
+```bash
+bundle exec appraisal ar81 rake test
+```
+
+## Conventions
+
+- All lib files use `# frozen_string_literal: true`
+- Tests use Minitest (`ActiveSupport::TestCase`) with Mocha for mocking
+- Column creation tests live in `ddl_test.rb`; schema dump tests in `tasks_test.rb`

--- a/lib/active_record/connection_adapters/mysql2rgeo/spatial_column.rb
+++ b/lib/active_record/connection_adapters/mysql2rgeo/spatial_column.rb
@@ -54,6 +54,21 @@ module ActiveRecord # :nodoc:
           %i[geometry geography].include?(@sql_type_metadata.type)
         end
 
+        # Override equality to include spatial attributes (@srid, @limit).
+        # Rails 8.1's Deduplicable uses == and hash to deduplicate column objects
+        # across different tables. Without this override, two SpatialColumn objects
+        # that share the same base attributes (name, type, etc.) but differ in SRID
+        # are incorrectly treated as equal, causing the wrong column to be returned
+        # from the deduplication registry.
+        def ==(other)
+          super && @srid == other.srid && @limit == other.limit
+        end
+        alias :eql? :==
+
+        def hash
+          super ^ @srid.hash ^ @limit.hash
+        end
+
         private
 
         def set_geometric_type_from_name(name)

--- a/lib/active_record/connection_adapters/mysql2rgeo_adapter.rb
+++ b/lib/active_record/connection_adapters/mysql2rgeo_adapter.rb
@@ -80,23 +80,21 @@ module ActiveRecord
         DEFAULT_SRID
       end
 
-      def native_database_types
-        # Add spatial types
-        # Reference: https://dev.mysql.com/doc/refman/5.6/en/spatial-type-overview.html
-        super.merge(
-          geometry:            { name: "geometry" },
-          geometrycollection:  { name: "geometrycollection" },
-          linestring:          { name: "linestring" },
-          multi_line_string:   { name: "multilinestring" },
-          multi_point:         { name: "multipoint" },
-          multi_polygon:       { name: "multipolygon" },
-          spatial:             { name: "geometry" },
-          point:               { name: "point" },
-          polygon:             { name: "polygon" }
-        )
-      end
-
       class << self
+        # Reference: https://dev.mysql.com/doc/refman/5.6/en/spatial-type-overview.html
+        def native_database_types
+          super.merge(
+            geometry:            { name: "geometry" },
+            geometrycollection:  { name: "geometrycollection" },
+            linestring:          { name: "linestring" },
+            multi_line_string:   { name: "multilinestring" },
+            multi_point:         { name: "multipoint" },
+            multi_polygon:       { name: "multipolygon" },
+            spatial:             { name: "geometry" },
+            point:               { name: "point" },
+            polygon:             { name: "polygon" }
+          )
+        end
 
         private
           def initialize_type_map(m)

--- a/test/tasks_test.rb
+++ b/test/tasks_test.rb
@@ -58,8 +58,8 @@ class TasksTest < ActiveSupport::TestCase
       ActiveRecord::SchemaDumper.dump(connection, file)
     end
     data = File.read(tmp_sql_filename)
-    assert_includes data, "t.geometry \"object1\", limit: {:type=>\"geometry\", :srid=>#{connection.default_srid}"
-    assert_includes data, "t.geometry \"object2\", limit: {:type=>\"geometry\", :srid=>#{connection.default_srid}"
+    assert_includes data, "t.geometry \"object1\", limit: {type: \"geometry\", srid: #{connection.default_srid}"
+    assert_includes data, "t.geometry \"object2\", limit: {type: \"geometry\", srid: #{connection.default_srid}"
   end
 
   def test_basic_geography_schema_dump
@@ -72,14 +72,41 @@ class TasksTest < ActiveSupport::TestCase
       ActiveRecord::SchemaDumper.dump(connection, file)
     end
     data = File.read(tmp_sql_filename)
-    assert_includes data, %(t.geometry "latlon1", limit: {:type=>"point", :srid=>0})
+    assert_includes data, %(t.geometry "latlon1", limit: {type: "point", srid: 0})
     if connection.supports_index_sort_order?
       assert_includes(data,
-                      %(t.geometry "latlon2", limit: {:type=>"point", :srid=>4326}))
+                      %(t.geometry "latlon2", limit: {type: "point", srid: 4326}))
     else
       assert_includes(data,
-                      %(t.geometry "latlon2", limit: {:type=>"point", :srid=>0}))
+                      %(t.geometry "latlon2", limit: {type: "point", srid: 0}))
     end
+  end
+
+  def test_all_spatial_types_schema_dump
+    setup_database_tasks
+    connection.create_table(:spatial_test, force: true) do |t|
+      t.geometry "geo_col"
+      t.point "pt_col"
+      t.linestring "ls_col"
+      t.polygon "poly_col"
+      t.multipoint "mpt_col"
+      t.multilinestring "mls_col"
+      t.multipolygon "mpoly_col"
+      t.geometrycollection "gc_col"
+    end
+    File.open(tmp_sql_filename, "w:utf-8") do |file|
+      ActiveRecord::SchemaDumper.dump(connection, file)
+    end
+    data = File.read(tmp_sql_filename)
+    refute_includes data, "Could not dump"
+    assert_includes data, %(t.geometry "geo_col", limit: {type: "geometry", srid: 0})
+    assert_includes data, %(t.geometry "pt_col", limit: {type: "point", srid: 0})
+    assert_includes data, %(t.geometry "ls_col", limit: {type: "line_string", srid: 0})
+    assert_includes data, %(t.geometry "poly_col", limit: {type: "polygon", srid: 0})
+    assert_includes data, %(t.geometry "mpt_col", limit: {type: "multi_point", srid: 0})
+    assert_includes data, %(t.geometry "mls_col", limit: {type: "multi_line_string", srid: 0})
+    assert_includes data, %(t.geometry "mpoly_col", limit: {type: "multi_polygon", srid: 0})
+    assert_includes data, %(t.geometry "gc_col", limit: {type: "geometry_collection", srid: 0})
   end
 
   def test_index_schema_dump
@@ -93,7 +120,7 @@ class TasksTest < ActiveSupport::TestCase
     end
     data = File.read(tmp_sql_filename)
     puts data
-    assert_includes data, %(t.geometry "latlon", limit: {:type=>"point", :srid=>0}, null: false)
+    assert_includes data, %(t.geometry "latlon", limit: {type: "point", srid: 0}, null: false)
     assert_includes data, %(t.index ["latlon"], name: "index_spatial_test_on_latlon", type: :spatial)
   end
 

--- a/test/tasks_test.rb
+++ b/test/tasks_test.rb
@@ -57,7 +57,7 @@ class TasksTest < ActiveSupport::TestCase
     File.open(tmp_sql_filename, "w:utf-8") do |file|
       ActiveRecord::SchemaDumper.dump(connection, file)
     end
-    data = File.read(tmp_sql_filename)
+    data = normalize_schema(File.read(tmp_sql_filename))
     assert_includes data, "t.geometry \"object1\", limit: {type: \"geometry\", srid: #{connection.default_srid}"
     assert_includes data, "t.geometry \"object2\", limit: {type: \"geometry\", srid: #{connection.default_srid}"
   end
@@ -71,7 +71,7 @@ class TasksTest < ActiveSupport::TestCase
     File.open(tmp_sql_filename, "w:utf-8") do |file|
       ActiveRecord::SchemaDumper.dump(connection, file)
     end
-    data = File.read(tmp_sql_filename)
+    data = normalize_schema(File.read(tmp_sql_filename))
     assert_includes data, %(t.geometry "latlon1", limit: {type: "point", srid: 0})
     if connection.supports_index_sort_order?
       assert_includes(data,
@@ -97,7 +97,7 @@ class TasksTest < ActiveSupport::TestCase
     File.open(tmp_sql_filename, "w:utf-8") do |file|
       ActiveRecord::SchemaDumper.dump(connection, file)
     end
-    data = File.read(tmp_sql_filename)
+    data = normalize_schema(File.read(tmp_sql_filename))
     refute_includes data, "Could not dump"
     assert_includes data, %(t.geometry "geo_col", limit: {type: "geometry", srid: 0})
     assert_includes data, %(t.geometry "pt_col", limit: {type: "point", srid: 0})
@@ -118,7 +118,7 @@ class TasksTest < ActiveSupport::TestCase
     File.open(tmp_sql_filename, "w:utf-8") do |file|
       ActiveRecord::SchemaDumper.dump(connection, file)
     end
-    data = File.read(tmp_sql_filename)
+    data = normalize_schema(File.read(tmp_sql_filename))
     puts data
     assert_includes data, %(t.geometry "latlon", limit: {type: "point", srid: 0}, null: false)
     assert_includes data, %(t.index ["latlon"], name: "index_spatial_test_on_latlon", type: :spatial)
@@ -147,6 +147,13 @@ class TasksTest < ActiveSupport::TestCase
   # end
 
   private
+
+  # Normalize Hash#inspect output to Ruby 3.4+ keyword-style format so that
+  # schema dump assertions work across all supported Ruby versions.
+  # Ruby < 3.4 prints {  :key=>"value"  }; Ruby 3.4+ prints {  key: "value"  }.
+  def normalize_schema(data)
+    data.gsub(/:(\w+)=>/, '\1: ')
+  end
 
   def new_connection(options = {})
     configuration_options = { "database" => "mysql2rgeo_tasks_test" }.merge(options)


### PR DESCRIPTION
> [!WARNING]
> 🤖 This pull request was prepared in collaboration with AI.
> The author reviewed and curated the proposed changes before requesting team review.

## Summary

Rails 8.1's `SchemaDumper` calls `valid_type?(column.type)` before writing each column definition. The instance `valid_type?` delegates to the **class-level** `native_database_types` (inherited from `AbstractMysqlAdapter`), which does not include spatial types — so every spatial column fails with a `# Could not dump table "..." because of following StandardError / Unknown type 'multipolygon'` error when `db/schema.rb` is regenerated.

This PR fixes schema dump for all spatial column types and also resolves a pre-existing `Deduplicable` regression first introduced in the `rails-8-1-support` branch.

## Changes

### `lib/active_record/connection_adapters/mysql2rgeo_adapter.rb`
Moved `native_database_types` from an instance method into `class << self`. Rails 8.1's `valid_type?` consults the **class-level** `native_database_types`, so spatial types must be registered there for `valid_type?(:geometry)` to return `true` and allow spatial columns to be dumped.

### `lib/active_record/connection_adapters/mysql2rgeo/spatial_column.rb`
Added `==`, `eql?`, and `hash` overrides that include `@srid` and `@limit`. Rails 8.1 introduced `Deduplicable`, which caches column objects in a class-level registry keyed by `==`/`hash`. `AbstractColumn#==` does not compare spatial attributes, so two `SpatialColumn` objects with the same name but different SRIDs were incorrectly considered equal — causing the deduplication registry to return the first-seen column regardless of SRID. This affected both `test_reload_dumped_schema` (pre-existing failure in `rails-8-1-support`) and `test_basic_geography_schema_dump`.

### `test/tasks_test.rb`
- Added `test_all_spatial_types_schema_dump`: creates a table with all 8 spatial types and asserts each dumps without error and with the correct `type`/`srid` in the `limit:` hash. This test directly reproduces the schema dump bug and confirms the fix.
- Added `normalize_schema` helper that converts Ruby < 3.4 Hash inspect format (`{:type=>"geometry", :srid=>0}`) to Ruby 3.4 style (`{type: "geometry", srid: 0}`) before asserting, so schema dump assertions are Ruby-version-agnostic.
- Updated 4 existing schema dump assertions to use the normalized format via `normalize_schema`.

### `.github/workflows/tests.yml`
- Updated the gemfile matrix entry from `ar72.gemfile` (which does not exist in this branch) to `ar81.gemfile`.
- Updated the Ruby matrix from `['3.3', '3.2', '3.1']` to `['3.4', '3.3', '3.2']` — Ruby 3.1 is incompatible with ActiveRecord 8.1 (which requires Ruby >= 3.2), and Ruby 3.4 is the version used for local development and testing.

## Testing

All 54 tests pass across Ruby 3.2, 3.3, and 3.4 with MySQL 8.0, including across multiple random seeds that previously exposed ordering-dependent failures. Prior to this fix, the `rails-8-1-support` branch had 3–4 test failures depending on seed; this branch has 0.

```
54 runs, 176 assertions, 0 failures, 0 errors, 0 skips
```

## QA Test Plan

**New Behavior**
- [x] After applying a pending migration with `rake db:migrate`, `db/schema.rb` is regenerated without any `# Could not dump table` errors for tables that contain spatial columns (`geometry`, `point`, `multipolygon`, etc.).
- [x] All spatial column definitions are present in the regenerated `db/schema.rb` with correct `type` and `srid` values in the `limit:` hash.
- [x] A spatial column created with an explicit SRID (e.g. `srid: 4326`) retains that SRID in the schema dump, and a column created without an explicit SRID correctly shows `srid: 0`.
- [x] Running `rake db:schema:load` after regenerating `db/schema.rb` succeeds — the dumped schema can be round-tripped without error.

**Regression**
- [x] Non-spatial tables (e.g. tables with only string, integer, datetime columns) continue to dump correctly in `db/schema.rb`.
- [x] Spatial queries (`ST_Distance`, `ST_Length`, etc.) continue to work correctly after the gem update — spatial column read/write behavior is unaffected.
- [x] The full CloudVault test suite passes with this gem version, including any existing tests that exercise spatial columns.